### PR TITLE
Improved trigger parsing

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,6 +1,6 @@
 var Bootstrap = {
     config: {
-      remoteUrl: 'https://rawgit.com/elitepvpers-community/smile/trigger_regex/'
+      remoteUrl: 'https://rawgit.com/elitepvpers-community/smile/master/'
     },
     init: function() { 
         var remoteScriptsUrl = Bootstrap.config.remoteUrl + "scripts";

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,6 +1,6 @@
 var Bootstrap = {
     config: {
-      remoteUrl: 'https://rawgit.com/elitepvpers-community/smile/master/'
+      remoteUrl: 'https://rawgit.com/elitepvpers-community/smile/trigger_regex/'
     },
     init: function() { 
         var remoteScriptsUrl = Bootstrap.config.remoteUrl + "scripts";

--- a/scripts/modules/EVBE.js
+++ b/scripts/modules/EVBE.js
@@ -224,9 +224,9 @@ var EVBE = {
             { 
                 if(smiley.trigger)
                 {
-                    var replacedContent = $(element).val().replace(new RegExp("(?:\\s+|^)+(" + smiley.trigger + ")(?:\\s+|$)"), function(full, trigger)
+                    var replacedContent = $(element).val().replace(new RegExp("(\\s+|^)+(" + smiley.trigger + ")(\\s+|$)"), function(full, before, after)
                     { 
-                        return " " + EVBE.getBBCode(smiley) + " ";
+                        return before + EVBE.getBBCode(smiley) + after;
                     })
 
                     $(element).val(replacedContent);

--- a/scripts/modules/EVBE.js
+++ b/scripts/modules/EVBE.js
@@ -225,14 +225,10 @@ var EVBE = {
             { 
                 if(smiley.trigger)
                 {
-                    pattern = "(?:(?:\\S+\\s+)|(?:^\\s*))+(" + RegExp.escape(smiley.trigger) + ")(?:(\\s+\\S+)|(?:\\s*$))+";
-                    re = new RegExp(pattern, "g");
-                    matches = re.exec(content)
-                    if(matches === null) return;
-                    if(matches.length < 2) return;
-
-                    // insert an extra whitespace for productivity ;)
-                    $(element).val(content.replace(matches[1], EVBE.getBBCode(smiley) + " ")); 
+                    $(element).val(content.replace(new RegExp("(?:\\s+|^)+(" + smiley.trigger + ")(?:\\s+|$)"), function(full, trigger)
+                    { 
+                        return " " + EVBE.getBBCode(smiley) + " ";
+                    }));
                 }
             })  
         });

--- a/scripts/modules/EVBE.js
+++ b/scripts/modules/EVBE.js
@@ -5,6 +5,11 @@ Array.prototype.remove = function(from, to) {
     return this.push.apply(this, rest);
 };
 
+// Gracenotes - http://stackoverflow.com/questions/494035/how-do-you-pass-a-variable-to-a-regular-expression-javascript/494122#494122
+RegExp.escape = function(str) {
+    return (str+'').replace(/[.?*+^$[\]\\(){}|-]/g, "\\$&");
+};
+
 // EVBE
 var EVBE = {
     init: function() {
@@ -220,11 +225,14 @@ var EVBE = {
             { 
                 if(smiley.trigger)
                 {
-                    if(content.indexOf(smiley.trigger) > -1)
-                    {
-                        // insert an extra whitespace for productivity ;)
-                        $(element).val(content.replace(smiley.trigger, EVBE.getBBCode(smiley) + " ")); 
-                    }
+                    pattern = "(?:(?:\\S+\\s+)|(?:^\\s*))+(" + RegExp.escape(smiley.trigger) + ")(?:(\\s+\\S+)|(?:\\s*$))+";
+                    re = new RegExp(pattern, "g");
+                    matches = re.exec(content)
+                    if(matches === null) return;
+                    if(matches.length < 2) return;
+
+                    // insert an extra whitespace for productivity ;)
+                    $(element).val(content.replace(matches[1], EVBE.getBBCode(smiley) + " ")); 
                 }
             })  
         });

--- a/scripts/modules/EVBE.js
+++ b/scripts/modules/EVBE.js
@@ -224,7 +224,7 @@ var EVBE = {
             { 
                 if(smiley.trigger)
                 {
-                    var replacedContent = $(element).val().replace(new RegExp("(\\s+|^)+(" + smiley.trigger + ")(\\s+|$)"), function(full, before, after)
+                    var replacedContent = $(element).val().replace(new RegExp("(\\s+|^)+(" + smiley.trigger + ")(\\s+|$)"), function(full, before, trigger, after)
                     { 
                         return before + EVBE.getBBCode(smiley) + after;
                     })

--- a/scripts/modules/EVBE.js
+++ b/scripts/modules/EVBE.js
@@ -217,7 +217,6 @@ var EVBE = {
         // event is raised every time the content of the valid input element is changed
         $(validInputElements).bind('input propertychange', function()
         {
-            var content = $(this).val();
             var smileyCollection = SmileyCollection.deserialize("EVBE_Smiles");
 
             element = this;
@@ -225,10 +224,12 @@ var EVBE = {
             { 
                 if(smiley.trigger)
                 {
-                    $(element).val(content.replace(new RegExp("(?:\\s+|^)+(" + smiley.trigger + ")(?:\\s+|$)"), function(full, trigger)
+                    var replacedContent = $(element).val().replace(new RegExp("(?:\\s+|^)+(" + smiley.trigger + ")(?:\\s+|$)"), function(full, trigger)
                     { 
                         return " " + EVBE.getBBCode(smiley) + " ";
-                    }));
+                    })
+
+                    $(element).val(replacedContent);
                 }
             })  
         });


### PR DESCRIPTION
Trigger parsing can now be prevented if the trigger is wrapped by characters.

Examples:
- `hi! -kappa-` - works, `-kappa-` will be replaced with the url
- `-kappa-` - also works
- `"-kappa-"` - does not work since `-kappa-` is wrapped by `"` characters
- `hi-kappa-` - does not work since there is no whitespace between `hi` and `-kappa-`
